### PR TITLE
Correct capitalization for 'Wait' import

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,4 +2,4 @@ export * from './KeyboardMouse';
 export * from './Clipboard';
 export * from './Keycodes';
 export * from './Window';
-export * from './wait';
+export * from './Wait';


### PR DESCRIPTION
most filesystems aren't case insensitive; this line breaks NodeHotkey in linux.